### PR TITLE
Implement basic vocabulary learning view

### DIFF
--- a/App/Learning/Word.swift
+++ b/App/Learning/Word.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct Word {
+    let text: String
+    let imageName: String
+    let audioName: String
+    let sentence: String
+}

--- a/App/Learning/WordLearningView.swift
+++ b/App/Learning/WordLearningView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import AVFoundation
+
+struct WordLearningView: View {
+    let word: Word
+    private var player: AVAudioPlayer? {
+        guard let url = Bundle.main.url(forResource: word.audioName, withExtension: "mp3") else { return nil }
+        return try? AVAudioPlayer(contentsOf: url)
+    }
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text(word.text)
+                .font(.largeTitle)
+            Image(word.imageName)
+                .resizable()
+                .scaledToFit()
+                .frame(height: 200)
+            Button(action: {
+                player?.play()
+            }) {
+                Image(systemName: "speaker.wave.2.fill")
+                    .font(.largeTitle)
+            }
+            Text(word.sentence)
+                .font(.title2)
+                .padding()
+        }
+        .padding()
+    }
+}
+
+struct WordLearningView_Previews: PreviewProvider {
+    static var previews: some View {
+        let sample = Word(text: "apple",
+                          imageName: "apple_image",
+                          audioName: "apple_sound",
+                          sentence: "I eat an apple.")
+        WordLearningView(word: sample)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Childlearn
 
-此專案為兒童英文學習 App 的初始儲存庫。
+此專案為兒童英文學習 App 的初始儲存庫，目前包含基本的學習模組範例。
 
 - [架構概述](docs/architecture.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,9 +28,12 @@ Childlearn/
 │   └── architecture.md
 ├── App/
 │   ├── Learning/
+│   │   ├── Word.swift
+│   │   └── WordLearningView.swift
 │   ├── Interaction/
 │   └── Review/
 └── README.md
 ```
 
-此檔案將隨著專案進度持續更新。
+目前 `Learning` 資料夾中提供一個簡單的 `Word` 模型與 `WordLearningView` 範例畫面，
+示範如何呈現單字、圖片、發音與例句。此檔案將隨著專案進度持續更新。


### PR DESCRIPTION
## Summary
- create `App/Learning` directory with a minimal `Word` model
- add `WordLearningView` SwiftUI demo to show word, image, audio and sentence
- update architecture overview with new file layout
- update README with note about sample learning module

## Testing
- `swift --version`
- `swiftc App/Learning/Word.swift -o /tmp/wordtest`

------
https://chatgpt.com/codex/tasks/task_e_6842c13a5fa4832cae783573f5faba98