### PR TITLE
Fix Speech checker for non-Apple builds

### DIFF
--- a/App/Learning/SpeechPronunciationChecker.swift
+++ b/App/Learning/SpeechPronunciationChecker.swift
@@ -1,9 +1,24 @@
 import Foundation
+#if canImport(Combine)
+import Combine
+#endif
+#if canImport(Speech) && canImport(AVFoundation)
 import Speech
 import AVFoundation
-import Combine
+#endif
+
+#if !canImport(Combine)
+protocol ObservableObject: AnyObject {}
+@propertyWrapper struct Published<Value> {
+    var wrappedValue: Value
+    init(wrappedValue: Value) {
+        self.wrappedValue = wrappedValue
+    }
+}
+#endif
 
 /// 提供語音辨識來檢查使用者發音是否正確
+#if canImport(Speech) && canImport(AVFoundation)
 class SpeechPronunciationChecker: NSObject, ObservableObject {
     @Published var recognizedText: String = ""
 
@@ -53,3 +68,19 @@ class SpeechPronunciationChecker: NSObject, ObservableObject {
         recognitionTask = nil
     }
 }
+#else
+/// A fallback implementation used when the Speech framework is unavailable.
+class SpeechPronunciationChecker: ObservableObject {
+    @Published var recognizedText: String = ""
+
+    /// Dummy start method for non-Apple platforms.
+    func startRecognition() throws {
+        // In environments without the Speech framework we simply
+        // indicate that recognition is unsupported.
+        recognizedText = ""
+    }
+
+    /// Stop recognition - no-op in the fallback case.
+    func stopRecognition() {}
+}
+#endif

--- a/App/Learning/WordLearningView.swift
+++ b/App/Learning/WordLearningView.swift
@@ -1,11 +1,17 @@
 import SwiftUI
 import AVFoundation
+#if canImport(Speech)
 import Speech
+#endif
 
 struct WordLearningView: View {
     let word: Word
 
     @State private var player: AVAudioPlayer?
+    @StateObject private var checker = SpeechPronunciationChecker()
+    @State private var isRecording = false
+    @State private var showResult = false
+
     private let ttsService = GoogleNotebookTTSService()
 
     private func loadAudio() {
@@ -20,14 +26,6 @@ struct WordLearningView: View {
                 }
             }
         }
-
-    @StateObject private var checker = SpeechPronunciationChecker()
-    @State private var isRecording = false
-    @State private var showResult = false
-    private var player: AVAudioPlayer? {
-        guard let url = Bundle.main.url(forResource: word.audioName, withExtension: "mp3") else { return nil }
-        return try? AVAudioPlayer(contentsOf: url)
-
     }
 
     var body: some View {
@@ -41,17 +39,9 @@ struct WordLearningView: View {
                 .scaledToFit()
                 .frame(height: 200)
 
-            Button(action: {
-                if player == nil {
-                    loadAudio()
-                }
-                player?.play()
-            }) {
-                Image(systemName: "speaker.wave.2.fill")
-                    .font(.largeTitle)
-=======
             HStack(spacing: 40) {
                 Button(action: {
+                    if player == nil { loadAudio() }
                     player?.play()
                 }) {
                     Image(systemName: "speaker.wave.2.fill")
@@ -70,29 +60,33 @@ struct WordLearningView: View {
                     Image(systemName: isRecording ? "mic.fill" : "mic")
                         .font(.largeTitle)
                 }
-
             }
+
             Text(word.sentence)
                 .font(.title2)
                 .padding()
         }
         .padding()
-
         .onAppear(perform: loadAudio)
-
         .alert(isPresented: $showResult) {
-            Alert(title: Text("你的發音"), message: Text(checker.recognizedText), dismissButton: .default(Text("OK")))
+            Alert(
+                title: Text("你的發音"),
+                message: Text(checker.recognizedText),
+                dismissButton: .default(Text("OK"))
+            )
         }
     }
 }
 
 struct WordLearningView_Previews: PreviewProvider {
     static var previews: some View {
-        let sample = Word(text: "apple",
-                          imageName: "apple_image",
-                          audioName: "apple_sound",
-                          sentence: "I eat an apple.",
-                          translation: "蘋果")
+        let sample = Word(
+            text: "apple",
+            imageName: "apple_image",
+            audioName: "apple_sound",
+            sentence: "I eat an apple.",
+            translation: "蘋果"
+        )
         WordLearningView(word: sample)
     }
 }


### PR DESCRIPTION
## Summary
- guard imports using `canImport` so Linux builds don't fail
- provide stub implementations of `ObservableObject` and `@Published` when Combine isn't available

## Testing
- `swiftc -emit-object App/Learning/Word.swift App/Learning/WordList.swift App/Learning/GoogleNotebookTTSService.swift App/Learning/SpeechPronunciationChecker.swift App/Learning/WordLearningView.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_6842d41fcf74832cb773a63a89f7d8d8